### PR TITLE
Bandeira do cartão ocultando valor digitado

### DIFF
--- a/templates/credit-card/payment-form.php
+++ b/templates/credit-card/payment-form.php
@@ -13,11 +13,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <fieldset id="pagarme-credit-cart-form">
-	<p class="form-row form-row-first">
+	<p class="form-row">
 		<label for="pagarme-card-holder-name"><?php esc_html_e( 'Card Holder Name', 'woocommerce-pagarme' ); ?><span class="required">*</span></label>
 		<input id="pagarme-card-holder-name" class="input-text" type="text" autocomplete="off" style="font-size: 1.5em; padding: 8px;" />
 	</p>
-	<p class="form-row form-row-last">
+	<p class="form-row">
 		<label for="pagarme-card-number"><?php esc_html_e( 'Card Number', 'woocommerce-pagarme' ); ?> <span class="required">*</span></label>
 		<input id="pagarme-card-number" class="input-text wc-credit-card-form-card-number" type="text" maxlength="20" autocomplete="off" placeholder="&bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull;" style="font-size: 1.5em; padding: 8px;" />
 	</p>


### PR DESCRIPTION
Issue relacionada: https://github.com/claudiosanches/woocommerce-pagarme/issues/86

Ao **desabilitar** o uso do Checkout Pagar.me, a bandeira do cartão fica por cima dos dados inseridos no input de número do cartão.

Algumas informações:

- Problema ocorre em resoluções de tela menores (mobile), ou no desktop dependendo do tema.
- Pelo que vi, o Woocommerce Plugin é quem faz essa troca das imagens de fundo de cada bandeira conforme a digitação dos números do cartão. Para criar 2 campos, como a sugestão inicial da issue, teria que ser desenvolvido algo próprio para isso.
- Essa solução de deixar cada input em uma linha, acaba resolvendo até outro problema, pois além de a bandeira ocultar os números, também não aparecem todos os números do cartão no input.

**Seguem algumas imagens:**

**Antes:**
![galaxys5-antes](https://user-images.githubusercontent.com/29166727/80643692-e30b5e80-8a3e-11ea-9691-0999cccce141.jpg)
![mobile_antes](https://user-images.githubusercontent.com/29166727/80643542-a7709480-8a3e-11ea-8ca0-ec98b1b05be5.jpg)

**Depois da solução:**
![galaxys5-depois](https://user-images.githubusercontent.com/29166727/80643855-24037300-8a3f-11ea-98e3-6fd78cf465d2.jpg)
![Checkout - Bligewater Store - Google Chrome_2](https://user-images.githubusercontent.com/29166727/80643634-ca02ad80-8a3e-11ea-9dd1-a99f00d1e849.jpg)

